### PR TITLE
Fix inactive database default handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Run `npm ci` to install dependencies.
 - Start the development server with `npm run dev` and ensure it boots without errors.
 - Request `http://localhost:5000/api/databases` or `http://localhost:5000/api/queries` and confirm the response is not a 404.
+- Execute `npm test` and confirm the storage tests pass, including coverage for inactive databases.
 
 ## UNDO
 - Revert the commit that introduced this change (e.g. `git revert <commit-hash>`).

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "tsx server/index.ts",
     "start": "node --loader tsx server/index.ts",
-    "build": "echo \"No build step\""
+    "build": "echo \"No build step\"",
+    "test": "tsx server/storage.test.ts"
   },
   "dependencies": { "express": "^4.19.2" },
   "devDependencies": { "tsx": "^4.19.1", "typescript": "^5.6.2" }

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -1,0 +1,27 @@
+import { strict as assert } from "node:assert";
+import { MemStorage } from "./storage";
+
+const storage = new MemStorage();
+
+const inactiveDb = await storage.createDatabase({
+  name: "Inactive database",
+  type: "sqlite",
+  connectionString: null,
+  isActive: false,
+});
+
+assert.equal(
+  inactiveDb.isActive,
+  false,
+  "createDatabase should preserve an explicit false isActive flag",
+);
+
+const defaultDb = await storage.createDatabase({
+  name: "Default active database",
+});
+
+assert.equal(
+  defaultDb.isActive,
+  true,
+  "createDatabase should default isActive to true when omitted",
+);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -107,7 +107,7 @@ export class MemStorage implements IStorage {
       name: insertDatabase.name,
       type: insertDatabase.type || 'sqlite',
       connectionString: insertDatabase.connectionString || null,
-      isActive: insertDatabase.isActive || true,
+      isActive: insertDatabase.isActive ?? true,
       createdAt: new Date()
     };
     this.databases.set(id, database);


### PR DESCRIPTION
## Summary
- preserve explicitly inactive databases by defaulting `isActive` with nullish coalescing
- add a focused storage test to cover inactive database creation and default activation
- expose an npm test script and document the verification step in the changelog

## Testing
- npm ci
- npm test

## Checklist
- [x] Tests added or updated
- [x] CHANGELOG updated

## Files Touched
- CHANGELOG.md
- package.json
- server/storage.ts
- server/storage.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e1ecb80b9c832cb3f95472bc2a5971