### PR TITLE
Add sqlite3 driver support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
 ## VERIFY
-- Run `npm ci` to install dependencies.
-- Start the development server with `npm run dev` and ensure it boots without errors.
+- Run `npm ci` to install dependencies (ensure `sqlite3` is present; if registry access is blocked, document the failure).
+- Start the development server with `npm run dev` and ensure it boots without SQLite driver errors.
 - Request `http://localhost:5000/api/databases` or `http://localhost:5000/api/queries` and confirm the response is not a 404.
 
 ## UNDO
 - Revert the commit that introduced this change (e.g. `git revert <commit-hash>`).
+- Remove the `sqlite3` dependency from `package.json` and reinstall.
 - Restart the development server if it was running.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
     "start": "node --loader tsx server/index.ts",
     "build": "echo \"No build step\""
   },
-  "dependencies": { "express": "^4.19.2" },
-  "devDependencies": { "tsx": "^4.19.1", "typescript": "^5.6.2" }
+  "dependencies": {
+    "express": "^4.19.2",
+    "sqlite3": "^5.1.7"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.2"
+  }
 }

--- a/server/services/database.ts
+++ b/server/services/database.ts
@@ -1,6 +1,9 @@
 // Database service for connecting to PostgreSQL databases
 import path from "path";
 import fs from "fs";
+import sqlite3, { Database as SqliteDatabase } from "sqlite3";
+
+const sqlite = sqlite3.verbose();
 
 export interface QueryResult {
   rows: any[];
@@ -16,7 +19,7 @@ export interface QueryError {
 }
 
 export class DatabaseService {
-  private connections: Map<string, Database> = new Map();
+  private connections: Map<string, SqliteDatabase> = new Map();
 
   async executeQuery(connectionString: string, sql: string): Promise<QueryResult> {
     const startTime = Date.now();
@@ -145,7 +148,7 @@ export class DatabaseService {
     }
   }
 
-  private async getConnection(connectionString: string): Promise<Database> {
+  private async getConnection(connectionString: string): Promise<SqliteDatabase> {
     if (this.connections.has(connectionString)) {
       return this.connections.get(connectionString)!;
     }
@@ -157,7 +160,7 @@ export class DatabaseService {
     }
 
     return new Promise((resolve, reject) => {
-      const db = new sqlite3.Database(connectionString, (err) => {
+      const db = new sqlite.Database(connectionString, (err) => {
         if (err) {
           reject(this.formatError(err));
           return;

--- a/server/types/sqlite3.d.ts
+++ b/server/types/sqlite3.d.ts
@@ -1,0 +1,24 @@
+declare module "sqlite3" {
+  type Callback<T = unknown> = (err: Error | null, result?: T) => void;
+
+  export interface RunResult {
+    changes?: number;
+    lastID?: number;
+  }
+
+  export class Database {
+    constructor(filename: string, callback?: Callback<void>);
+    all<T = any>(sql: string, params: any[], callback: Callback<T[]>): void;
+    get<T = any>(sql: string, params: any[], callback: Callback<T>): void;
+    run(sql: string, params: any[], callback: (this: RunResult, err: Error | null) => void): void;
+    close(callback: Callback<void>): void;
+  }
+
+  export interface Sqlite3Module {
+    Database: typeof Database;
+    verbose(): Sqlite3Module;
+  }
+
+  const sqlite3: Sqlite3Module;
+  export default sqlite3;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,1 +1,1 @@
-{ "compilerOptions": { "target":"ES2020","module":"ESNext","moduleResolution":"NodeNext","esModuleInterop":true,"skipLibCheck":true }, "include":["server/**/*.ts"] }
+{ "compilerOptions": { "target":"ES2020","module":"ESNext","moduleResolution":"NodeNext","esModuleInterop":true,"skipLibCheck":true }, "include":["server/**/*.ts","server/**/*.d.ts"] }


### PR DESCRIPTION
## Summary
- add the sqlite3 runtime dependency so the server can open SQLite databases
- import the sqlite3 driver in the database service and tighten the connection map typing
- supply local type declarations and include them in the TypeScript configuration alongside changelog guidance

## Testing
- npm install *(fails: registry returned 403 for sqlite3/@types packages in the execution environment)*
- npm ci *(fails: registry returned 403 for sqlite3 in the execution environment)*
- npm test *(fails: no test script defined in package.json)*
- npm run dev *(fails: sqlite3 package unavailable because install is blocked by registry 403)*

## Checklist
- [x] Update CHANGELOG.md with VERIFY/UNDO guidance
- [x] Document files touched: package.json, server/services/database.ts, server/types/sqlite3.d.ts, tsconfig.json, CHANGELOG.md


------
https://chatgpt.com/codex/tasks/task_e_68e1ecb13260832c84f6012d20a5a387