### PR TITLE
Fix database creation to respect explicit inactive flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 - Run `npm ci` to install dependencies.
 - Start the development server with `npm run dev` and ensure it boots without errors.
 - Request `http://localhost:5000/api/databases` or `http://localhost:5000/api/queries` and confirm the response is not a 404.
+- Run `npm test` and ensure the database API test suite passes.
+- Issue a `POST http://localhost:5000/api/databases` with `{ "name": "test", "type": "sqlite", "isActive": false }` and confirm a subsequent `GET /api/databases` returns the new database with `isActive: false`.
 
 ## UNDO
 - Revert the commit that introduced this change (e.g. `git revert <commit-hash>`).
 - Restart the development server if it was running.
+- Delete any databases created while verifying the change if they are no longer needed.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "tsx server/index.ts",
     "start": "node --loader tsx server/index.ts",
-    "build": "echo \"No build step\""
+    "build": "echo \"No build step\"",
+    "test": "tsx --test tests/database-api.test.ts"
   },
   "dependencies": { "express": "^4.19.2" },
   "devDependencies": { "tsx": "^4.19.1", "typescript": "^5.6.2" }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -107,7 +107,7 @@ export class MemStorage implements IStorage {
       name: insertDatabase.name,
       type: insertDatabase.type || 'sqlite',
       connectionString: insertDatabase.connectionString || null,
-      isActive: insertDatabase.isActive || true,
+      isActive: insertDatabase.isActive ?? true,
       createdAt: new Date()
     };
     this.databases.set(id, database);

--- a/tests/database-api.test.ts
+++ b/tests/database-api.test.ts
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import type { AddressInfo } from "node:net";
+
+import { registerRoutes } from "../server/routes";
+
+function startAppServer(app: express.Express) {
+  return new Promise<ReturnType<typeof app.listen>>((resolve, reject) => {
+    const server = app.listen(0, "127.0.0.1", () => resolve(server));
+    server.on("error", reject);
+  });
+}
+
+test("POST /api/databases preserves explicit false isActive", async t => {
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  registerRoutes(app);
+
+  const server = await startAppServer(app);
+  t.after(() => new Promise<void>((resolve, reject) => {
+    server.close(error => (error ? reject(error) : resolve()));
+  }));
+
+  const { port } = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  const createResponse = await fetch(`${baseUrl}/api/databases`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      name: "Inactive database",
+      type: "sqlite",
+      isActive: false,
+    }),
+  });
+
+  assert.strictEqual(createResponse.status, 200);
+  const createdDatabase = await createResponse.json();
+  assert.strictEqual(createdDatabase.isActive, false);
+
+  const listResponse = await fetch(`${baseUrl}/api/databases`);
+  assert.strictEqual(listResponse.status, 200);
+
+  const databases = await listResponse.json();
+  const storedDatabase = Array.isArray(databases)
+    ? databases.find((database: any) => database.id === createdDatabase.id)
+    : undefined;
+
+  assert.ok(storedDatabase, "Created database should be returned by /api/databases");
+  assert.strictEqual(storedDatabase?.isActive, false);
+});


### PR DESCRIPTION
## Summary
- ensure the in-memory storage keeps explicitly provided `isActive: false` values when inserting databases
- add an integration-style test that exercises the `/api/databases` endpoints to confirm the inactive flag persists
- expose an npm `test` script and document the new verification steps

## Testing
- [x] npm ci
- [x] npm test

## Files Touched
- server/storage.ts
- tests/database-api.test.ts
- package.json
- CHANGELOG.md

------
https://chatgpt.com/codex/tasks/task_e_68e1eca2715c832ca41f0d8cdf7b0296