### PR TITLE
Fix default database selection effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Start the development server with `npm run dev` and ensure it boots without SQLite driver errors.
 - Request `http://localhost:5000/api/databases` or `http://localhost:5000/api/queries` and confirm the response is not a 404.
 - Execute `npm test` and confirm the storage tests pass, including coverage for inactive databases.
+- In the query input UI, confirm the database dropdown selects the first available connection automatically and that queries run without needing to reselect the database.
 
 ## UNDO
 - Revert the commit that introduced this change (e.g. `git revert <commit-hash>`).

--- a/client/src/components/query-input.tsx
+++ b/client/src/components/query-input.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Sparkles, Lightbulb } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -18,13 +18,13 @@ export default function QueryInput({ onQueryExecuted }: QueryInputProps) {
   const [selectedDatabaseId, setSelectedDatabaseId] = useState("");
   const { toast } = useToast();
   const { data: databases = [] } = useDatabases();
+  const userSelectedRef = useRef(false);
 
-  // Set default database
-  useState(() => {
-    if (databases.length > 0 && !selectedDatabaseId) {
+  useEffect(() => {
+    if (!userSelectedRef.current && !selectedDatabaseId && databases.length > 0) {
       setSelectedDatabaseId(databases[0].id);
     }
-  });
+  }, [databases, selectedDatabaseId]);
 
   const translateMutation = useMutation({
     mutationFn: async (data: { naturalLanguage: string; databaseId?: string }) => {
@@ -155,7 +155,10 @@ export default function QueryInput({ onQueryExecuted }: QueryInputProps) {
             {databases.length > 0 && (
               <select
                 value={selectedDatabaseId}
-                onChange={(e) => setSelectedDatabaseId(e.target.value)}
+                onChange={(e) => {
+                  userSelectedRef.current = true;
+                  setSelectedDatabaseId(e.target.value);
+                }}
                 className="text-xs bg-input border border-border rounded px-2 py-1 text-foreground"
                 data-testid="select-database"
               >


### PR DESCRIPTION
## Summary
- replace the placeholder state initializer with an effect that assigns the first database once the list is available
- track when a user manually chooses a connection so the automatic default is not reapplied
- document the verification step for the new dropdown behavior in the changelog

## Testing
- npm ci *(fails: 403 Forbidden - GET https://registry.npmjs.org/sqlite3)*
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e1f4d62810832cbc5ce7dcfa1dcb1d