### PR TITLE
Fix sqlite3 import usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 - Start the development server with `npm run dev` and ensure it boots without SQLite driver errors.
 - Request `http://localhost:5000/api/databases` or `http://localhost:5000/api/queries` and confirm the response is not a 404.
 - Execute `npm test` and confirm the storage tests pass, including coverage for inactive databases.
+- Send a POST to `http://localhost:5000/api/queries/execute` with a simple query (e.g. `SELECT 1`) to verify SQLite connections open successfully.
 
 ## UNDO
 - Revert the commit that introduced this change (e.g. `git revert <commit-hash>`).
 - Remove the `sqlite3` dependency from `package.json` and reinstall.
 - Restart the development server if it was running.
+- Delete the SQLite import in `server/services/database.ts` if removing the dependency manually.

--- a/server/services/database.ts
+++ b/server/services/database.ts
@@ -1,7 +1,8 @@
 // Database service for connecting to PostgreSQL databases
 import path from "path";
 import fs from "fs";
-import sqlite3, { Database as SqliteDatabase } from "sqlite3";
+import sqlite3 from "sqlite3";
+import type { Database as SqliteDatabase } from "sqlite3";
 
 const sqlite = sqlite3.verbose();
 


### PR DESCRIPTION
## Summary
- import the sqlite3 runtime and Database type explicitly in the database service to align with ESM expectations
- document how to verify query execution via /api/queries/execute in the changelog

## Testing
- `npm ci` *(fails: 403 Forbidden fetching sqlite3)*
- `npm test`
- `npm run dev` *(fails: sqlite3 package missing because install is blocked)*

## Checklist
- [x] CHANGELOG updated
- [ ] Dependencies installed successfully

## Files Touched
- CHANGELOG.md
- server/services/database.ts

------
https://chatgpt.com/codex/tasks/task_e_68e1f4ce4088832ca6de10f426e12182