### PR TITLE
fix: auto-select default query database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Run `npm ci` to install dependencies.
 - Start the development server with `npm run dev` and ensure it boots without errors.
 - Request `http://localhost:5000/api/databases` or `http://localhost:5000/api/queries` and confirm the response is not a 404.
+- Open the query interface and confirm the database dropdown auto-selects the first connection once connections load.
+- Execute a natural language query end-to-end to ensure translation and execution succeed without needing manual database selection.
 
 ## UNDO
 - Revert the commit that introduced this change (e.g. `git revert <commit-hash>`).

--- a/client/src/components/query-input.tsx
+++ b/client/src/components/query-input.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Sparkles, Lightbulb } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -19,12 +19,11 @@ export default function QueryInput({ onQueryExecuted }: QueryInputProps) {
   const { toast } = useToast();
   const { data: databases = [] } = useDatabases();
 
-  // Set default database
-  useState(() => {
+  useEffect(() => {
     if (databases.length > 0 && !selectedDatabaseId) {
       setSelectedDatabaseId(databases[0].id);
     }
-  });
+  }, [databases, selectedDatabaseId]);
 
   const translateMutation = useMutation({
     mutationFn: async (data: { naturalLanguage: string; databaseId?: string }) => {


### PR DESCRIPTION
## Summary
- switch the query input component to initialize the selected database via a guarded effect so lists can hydrate before choosing a default
- document the new verification expectations in the changelog

## Testing
- `npm ci`
- `npm test` *(fails: Missing script "test")*

## Checklist
- [x] Ready for review

## Files Touched
- client/src/components/query-input.tsx
- CHANGELOG.md

## Additional Context
- Unable to start the Vite dev server for UI verification because fetching the `vite` package returned `403 Forbidden` from the npm registry.

------
https://chatgpt.com/codex/tasks/task_e_68e1ec9cad54832c8cacdddda429c777