### PR TITLE
Fix query input database selection guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Send a POST to `http://localhost:5000/api/queries/execute` with a simple query (e.g. `SELECT 1`) to verify SQLite connections open successfully.
 - POST `{"naturalLanguage":"List all customers"}` to `http://localhost:5000/api/queries/translate` and verify a JSON payload is returned without OpenAI module errors.
 - In the query input UI, confirm the database dropdown selects the first available connection automatically and that queries run without needing to reselect the database.
+- After manually selecting a different database in the query input UI, trigger a refresh of the database list and confirm the dropdown preserves the manual choice instead of resetting to the first option.
 - Using the API, create a database with `isActive: false`.
   Verify that a subsequent `GET /api/databases` response preserves the `false` flag.
 - Review `docs/task-findings.md` for the latest maintenance task recommendations and triage them as needed.
@@ -24,6 +25,7 @@
 - Restore the Queries, Reports, and Settings page layouts to their previous ShadCN `Card` implementations if the SmartFlow glass treatment needs to be rolled back.
 - Revert the commit that introduced this change (e.g. `git revert <commit-hash>`).
 - Remove the `sqlite3` dependency from `package.json` and reinstall.
+- Remove the query input guard that checks `userSelectedRef` if the dropdown should always default to the first database when the list reloads.
 - Restart the development server if it was running.
 - Delete any databases created while verifying the change if they are no longer needed.
 - Remove the exported `server` instance from `server/index.ts` if it is no longer needed.

--- a/client/src/components/query-input.tsx
+++ b/client/src/components/query-input.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { useEffect, useRef, useState } from "react";
 import { Sparkles, Lightbulb } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -22,7 +21,6 @@ export default function QueryInput({ onQueryExecuted }: QueryInputProps) {
   const userSelectedRef = useRef(false);
 
   useEffect(() => {
-    if (databases.length > 0 && !selectedDatabaseId) {
     if (!userSelectedRef.current && !selectedDatabaseId && databases.length > 0) {
       setSelectedDatabaseId(databases[0].id);
     }


### PR DESCRIPTION
## Summary
- deduplicate the React imports in `QueryInput`
- tighten the default database selection guard to respect manual choices
- document verification and rollback steps for the dropdown behavior

## Testing
- `npm ci` *(fails: 403 Forbidden fetching sqlite3 from npm registry)*
- `npm test` *(fails: tsx command not found due to missing dependencies)*

## Checklist
- [x] npm ci *(documented failure)*
- [x] npm test *(documented failure)*

## Files Touched
- CHANGELOG.md
- client/src/components/query-input.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e22e462260832c8ba322ee76066b55