### PR TITLE
Merge duplicate tsconfig configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## VERIFY
+- Inspect `tsconfig.json` to confirm it now contains a single merged configuration object and rerun `npm test` to validate TypeScript compilation succeeds.
 - Visit the Queries, Reports, and Settings pages to confirm the dashboard-style background, marbled scroll region, and glass cards render consistently with the updated SmartFlow visual system.
 - Run `npm ci` to install dependencies (ensure `sqlite3` is present; if registry access is blocked, document the failure).
 - Start the development server with `npm run dev` and ensure it boots without SQLite driver errors.
@@ -21,6 +22,7 @@
 - Review `docs/task-findings.md` for the latest maintenance task recommendations and triage them as needed.
 
 ## UNDO
+- Revert `tsconfig.json` to its prior duplicate-block structure if the consolidated configuration causes issues.
 - Restore the Queries, Reports, and Settings page layouts to their previous ShadCN `Card` implementations if the SmartFlow glass treatment needs to be rolled back.
 - Revert the commit that introduced this change (e.g. `git revert <commit-hash>`).
 - Remove the `sqlite3` dependency from `package.json` and reinstall.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["server/**/*.ts"]
+  "include": [
+    "server/**/*.ts",
+    "server/**/*.d.ts"
+  ]
 }
-{ "compilerOptions": { "target":"ES2020","module":"ESNext","moduleResolution":"NodeNext","esModuleInterop":true,"skipLibCheck":true }, "include":["server/**/*.ts","server/**/*.d.ts"] }


### PR DESCRIPTION
## Summary
- merge the duplicate tsconfig.json blocks into a single configuration object that includes TypeScript sources and declaration files
- document the verification and rollback steps for the consolidated TypeScript configuration in CHANGELOG.md

## Testing
- npm ci *(fails: 403 Forbidden retrieving sqlite3 from registry.npmjs.org)*
- npm test *(fails: `tsx` not found because dependencies were not installed)*

## Checklist
- [x] CHANGELOG updated
- [x] npm ci
- [x] npm test

## Files Touched
- tsconfig.json
- CHANGELOG.md

------
https://chatgpt.com/codex/tasks/task_e_68e22e51b48c832cbac8b0314406d120