### PR TITLE
Fix: Deduplicate sqlite import in database service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## VERIFY
 - Visit the Queries, Reports, and Settings pages to confirm the dashboard-style background, marbled scroll region, and glass cards render consistently with the updated SmartFlow visual system.
 - Run `npm ci` to install dependencies (ensure `sqlite3` is present; if registry access is blocked, document the failure).
+- Confirm `server/services/database.ts` only declares a single `import sqlite3 from "sqlite3";` statement.
 - Start the development server with `npm run dev` and ensure it boots without SQLite driver errors.
 - Request `http://localhost:5000/api/databases` or `http://localhost:5000/api/queries` and confirm the response is not a 404.
 - Exercise `POST http://localhost:5000/api/queries/execute` with a simple SELECT query and confirm it succeeds without SQLite connection errors.
@@ -28,4 +29,5 @@
 - Delete any databases created while verifying the change if they are no longer needed.
 - Remove the exported `server` instance from `server/index.ts` if it is no longer needed.
 - Delete the SQLite import in `server/services/database.ts` if removing the dependency manually.
+- Reintroduce the duplicate `import sqlite3 from "sqlite3";` line in `server/services/database.ts` if this change must be reverted.
 - Delete the `vendor/openai` directory (and re-run dependency installation) to remove the local OpenAI stub if reverting.

--- a/server/services/database.ts
+++ b/server/services/database.ts
@@ -2,7 +2,6 @@
 import sqlite3 from "sqlite3";
 import path from "path";
 import fs from "fs";
-import sqlite3 from "sqlite3";
 import type { Database as SqliteDatabase } from "sqlite3";
 
 const sqlite = sqlite3.verbose();


### PR DESCRIPTION
## Summary
- remove the duplicate `sqlite3` default import in `server/services/database.ts` while keeping the type-only import intact
- document new VERIFY/UNDO guidance in `CHANGELOG.md` covering the single `sqlite3` import expectation and how to revert it

## Testing
- npm ci *(fails: 403 Forbidden fetching sqlite3 from npm registry)*
- npm test *(fails: `tsx` command unavailable because dependencies were not installed after npm ci failure)*

## Checklist
- [x] CHANGELOG updated
- [ ] Additional manual QA complete

## Files Touched
- server/services/database.ts
- CHANGELOG.md

------
https://chatgpt.com/codex/tasks/task_e_68e22e4f7bf0832c96100b9110a1e650