### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "express": "^4.19.2",
     "sqlite3": "^5.1.7",
-    "openai": "file:vendor/openai"
+    "openai": "file:vendor/openai",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "tsx": "^4.19.1",

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,7 @@ import express from "express";
 import { exec } from "node:child_process";
 import * as path from "node:path";
 import * as fs from "node:fs";
-
+import rateLimit from "express-rate-limit";
 import { registerRoutes } from "./routes";
 
 const app = express();
@@ -14,8 +14,16 @@ app.get("/api/health", (_req, res) => {
   res.json({ ok: true, app: "SFSDataQueryEngine" });
 });
 
+// Rate limiter for sync endpoint: 5 requests per minute per IP
+const syncLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 5, // limit each IP to 5 requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 // Force sync from GitHub (OVERWRITES)
-app.post("/gh-sync", (req, res) => {
+app.post("/gh-sync", syncLimiter, (req, res) => {
   const ok = req.get("authorization") === `Bearer ${process.env.SYNC_TOKEN}`;
   if (!ok) return res.status(401).json({ ok: false });
   const ref = (req.body?.ref as string) || "main";


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SFSDataQueryEngine/security/code-scanning/6](https://github.com/smartflow-systems/SFSDataQueryEngine/security/code-scanning/6)

To address the lack of rate limiting on the `/gh-sync` endpoint, we should add a rate-limiting middleware specifically to this route. The best and most standard approach in an Express application is to use `express-rate-limit`, a mature, well-known library. We will import `express-rate-limit`, configure a limiter (for example: 5 requests per minute per IP should be sufficient for this sensitive operation), and apply it only to the `/gh-sync` POST route.

Required changes:
- Add `import rateLimit from "express-rate-limit";` at the top.
- Define a rate limiter instance (e.g., `const syncLimiter = rateLimit({...});`) with suitable options (e.g., windowMs: 60 * 1000, max: 5).
- Add the limiter as middleware to the `/gh-sync` route (e.g., `app.post("/gh-sync", syncLimiter, (req, res) => { ... });`).

No changes to the core logic or existing functionality are needed; only the introduction and use of the rate limiter.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
