### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -112,7 +112,7 @@ export function registerRoutes(app: Express): void {
 
   app.post("/api/queries/execute", async (req, res) => {
     try {
-      const { sql, databaseId, naturalLanguage, save } = req.body;
+      const { sql, databaseId, naturalLanguage, save, params } = req.body;
       
       if (!sql || !databaseId) {
         return res.status(400).json({ message: "SQL query and database ID are required" });
@@ -133,7 +133,7 @@ export function registerRoutes(app: Express): void {
       }
 
       // Execute query
-      const result = await databaseService.executeQuery(database.connectionString || "", sql);
+      const result = await databaseService.executeQuery(database.connectionString || "", sql, params || []);
       
       // Save query if requested or if it should be saved automatically  
       const queryData: any = {

--- a/server/services/database.ts
+++ b/server/services/database.ts
@@ -23,7 +23,7 @@ export interface QueryError {
 export class DatabaseService {
   private connections: Map<string, SqliteDatabase> = new Map();
 
-  async executeQuery(connectionString: string, sql: string): Promise<QueryResult> {
+  async executeQuery(connectionString: string, sql: string, params: any[] = []): Promise<QueryResult> {
     const startTime = Date.now();
     
     try {
@@ -32,7 +32,7 @@ export class DatabaseService {
       return new Promise((resolve, reject) => {
         // For SELECT queries
         if (sql.trim().toLowerCase().startsWith('select')) {
-          db.all(sql, [], (err, rows) => {
+          db.all(sql, params, (err, rows) => {
             if (err) {
               reject(this.formatError(err));
               return;
@@ -51,7 +51,7 @@ export class DatabaseService {
         } else {
           // For INSERT, UPDATE, DELETE queries
           const self = this;
-          db.run(sql, [], function(err) {
+          db.run(sql, params, function(err) {
             if (err) {
               reject(self.formatError(err));
               return;


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SFSDataQueryEngine/security/code-scanning/2](https://github.com/smartflow-systems/SFSDataQueryEngine/security/code-scanning/2)

The best way to fix this problem is to ensure all untrusted user input is embedded in SQL queries using parameters ("prepared statements"), rather than string concatenation or direct query embedding. For the `sqlite3` Node.js library, this means using `db.all` and `db.run` methods with parameterized queries, where data is supplied as a second argument (an array of parameters), and the SQL string itself is constructed with `?` placeholders.

As the design currently seems to allow arbitrary SQL, the ideal fix would be to change the API so instead of sending fully-formed SQL from the client, it sends:
- the query with `?` placeholders
- an array of values to inject

However, if this is not possible with this codebase’s current structure, we can try to detect non-parameterized queries and reject them, or escape input query values. The best and standard fix is to ONLY support parameterized queries and require both client and server to pass them safely.

**Required changes:**
- In `/api/queries/execute`, change from submitting raw SQL to submitting a query template (with `?` placeholders) AND a `params` array, transforming e.g. `SELECT * FROM users WHERE name = ?` and `["Alice"]`.
- In `DatabaseService.executeQuery`, accept a third optional `params` argument (default `[]`), and pass it to `db.all` and `db.run` as the second argument.
- Refactor the route to accept and pass these params securely.
- Optionally, validate that queries have only parameter markers and not user-embedded values.
- Update all code paths that call executeQuery.

**Files to edit:** 
- `server/routes.ts`: Accept and pass a `params` array.
- `server/services/database.ts`: Accept `params` and use them properly.

**No new imports are needed.**

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
