### PR TITLE
Potential fix for code scanning alert no. 11: Database query built from user-controlled sources

### DIFF
--- a/server/services/database.ts
+++ b/server/services/database.ts
@@ -23,9 +23,26 @@ export interface QueryError {
 export class DatabaseService {
   private connections: Map<string, SqliteDatabase> = new Map();
 
+  // Only allow SELECT/INSERT/UPDATE/DELETE, no dangerous or multiple statements
+  private isSafeSQL(sql: string): boolean {
+    const trimmed = sql.trim();
+    // Allow only one statement, and only if starts with allowed verb
+    // Block semicolons, PRAGMA, ATTACH, DETACH, CREATE, DROP, ALTER
+    if (/;/.test(trimmed)) return false;
+    const unsafeKeywords = /\b(pragma|attach|detach|create|drop|alter|replace|vacuum|begin|commit|rollback|savepoint|release|grant|revoke)\b/i;
+    if (unsafeKeywords.test(trimmed)) return false;
+    // Allow only select/insert/update/delete as leading word
+    if (!/^(select|insert|update|delete)\b/i.test(trimmed)) return false;
+    return true;
+  }
+
   async executeQuery(connectionString: string, sql: string, params: any[] = []): Promise<QueryResult> {
     const startTime = Date.now();
     
+    if (!this.isSafeSQL(sql)) {
+      throw { message: "SQL query contains unsafe or forbidden statements." };
+    }
+
     try {
       const db = await this.getConnection(connectionString);
       


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SFSDataQueryEngine/security/code-scanning/11](https://github.com/smartflow-systems/SFSDataQueryEngine/security/code-scanning/11)

The best way to fix this problem is to only allow execution of whitelisted types of SQL commands and to ensure that any user-provided SQL is strictly parameterized, never interpolated into the query string. For an even stronger security posture, the backend should parse the incoming SQL query and block any queries that attempt to execute multiple statements or contain dangerous syntax (like `;`, `PRAGMA`, `ATTACH`, `DETACH`, or DDL statements). Since user-provided SQL queries are already being validated, we should augment this in the `executeQuery` function by adding a strict allow-list filter as a second-layer check, further restricting allowed statements to `SELECT`, `INSERT`, `UPDATE`, or `DELETE` (if appropriate for your application) and rejecting any others.

All changes are made in `server/services/database.ts` inside the `executeQuery` function. The logic will:
1. Add a helper method (e.g., `isSafeSQL`) to check that the SQL string is a single statement and matches an allowed pattern (e.g., it starts with a single allowed verb and contains no semicolons or dangerous keywords).
2. In `executeQuery`, before any database operations, call this method and throw an error if the check fails.
3. Optionally, adjust comments and error handling for clarity.

No third-party libraries are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
