### PR TITLE
Potential fix for code scanning alert no. 12: Database query built from user-controlled sources

### DIFF
--- a/server/services/database.ts
+++ b/server/services/database.ts
@@ -23,10 +23,31 @@ export interface QueryError {
 export class DatabaseService {
   private connections: Map<string, SqliteDatabase> = new Map();
 
+  /**
+   * Checks if the SQL statement is safe to execute.
+   * Only allows single SELECT, INSERT, UPDATE, DELETE statements.
+   * Disallows semicolons except possibly at the end, and comments.
+   */
+  private isSafeSqlStatement(sql: string): boolean {
+    const normalized = sql.trim().toLowerCase();
+    // Only allow SELECT, INSERT, UPDATE, DELETE at the beginning
+    if (!/^(select|insert|update|delete)\b/.test(normalized)) return false;
+    // Disallow multiple statements by semicolon (except possibly at end, but safest is fully disallow)
+    if (sql.includes(";")) return false;
+    // Disallow SQL comments
+    if (/--|\/*|\*\//.test(sql)) return false;
+    return true;
+  }
+
   async executeQuery(connectionString: string, sql: string, params: any[] = []): Promise<QueryResult> {
     const startTime = Date.now();
     
     try {
+      if (!this.isSafeSqlStatement(sql)) {
+        throw {
+          message: "Unsafe SQL statement detected. Only single SELECT, INSERT, UPDATE, DELETE statements are allowed.",
+        };
+      }
       const db = await this.getConnection(connectionString);
       
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
Potential fix for [https://github.com/smartflow-systems/SFSDataQueryEngine/security/code-scanning/12](https://github.com/smartflow-systems/SFSDataQueryEngine/security/code-scanning/12)

The best way to fix the problem is to ensure that user-provided SQL statements are not executed verbatim; instead, restrict execution to only trusted, pre-defined queries, or enforce strict syntax and potentially use a SQL parser that allows only certain operations, tables, or columns. However, as the context is a SQL IDE that executes ad-hoc queries from users, this is not possible.

Therefore, a strong fix is to ensure that the SQL statement does **not** contain multiple statements (`;` as a delimiter), as well as restricting to a safe subset of statements (ideally only SELECT, INSERT, UPDATE, DELETE). The external `validateAndOptimizeSQL` may not be rigorous enough, so it's best to add additional server-side SQL validation.

In practical terms:
- In `server/services/database.ts`, before executing the `sql` string, ensure that it contains only one statement and matches only the allowed query types using a regex (e.g., only SELECT/INSERT/UPDATE/DELETE).
- Reject any query containing a semicolon (except possibly at the end), comments, or potentially dangerous language.
- Consider using a library such as `sqlstring` for escaping, but that's mainly for parameters, not the SQL structure itself.
- Place the checks just before the lines that invoke `db.all` or `db.run`.

Implementation plan:
- Edit `executeQuery` in `server/services/database.ts` to add:
  - A type- and statement-checking helper for `sql`.
  - Check that `sql` starts with an allowed verb, contains only one statement, and doesn't contain `;` in unexpected places.
  - Reject anything that fails the test.
- Add a new helper method (e.g. `isSafeSqlStatement(sql: string): boolean`) inside `DatabaseService`.
- Use the helper inside `executeQuery` before running the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
